### PR TITLE
fix row ID collision when worksheets have same sheet ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-google-spreadsheets",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "A source plugin for Gatsby that allows reading data from Google Sheets.",
   "main": "index.js",
   "scripts": {

--- a/src/fetchSheet.ts
+++ b/src/fetchSheet.ts
@@ -21,7 +21,7 @@ export default async (
         return {
           [worksheet.title]: cleanRows(rows).map((row, id) =>
             Object.assign(row, {
-              id: hash(`${worksheet.sheetId}-${id}`),
+              id: hash(`${spreadsheetId}-${worksheet.sheetId}-${id}`),
             }),
           ),
         };


### PR DESCRIPTION
Fixes https://github.com/butlerx/gatsby-source-google-spreadsheets/issues/29

Looking at the code, a row ID is generated using a worksheet's internal ID and row number. So when two worksheets had same internal ID, rows from those worksheets would have duplicate IDs.

The fix is to simply include spreadsheet ID when generating a row ID, so the ID is always unique.