### PR TITLE
Fix: phone numbers convert to string

### DIFF
--- a/src/fetchSheet/cleanRows/columnsDataTypes.spec.ts
+++ b/src/fetchSheet/cleanRows/columnsDataTypes.spec.ts
@@ -84,4 +84,14 @@ describe('guessing column data type based on all cells in column', () => {
     expect(guessedTypes.nulls).toBeUndefined();
     expect(guessedTypes.booleans).toBe('boolean');
   });
+
+  it('phone numbers become string', () => {
+    const rows = [
+      {
+        phone: '0177-60606060',
+      },
+    ];
+    const guessedTypes = guessColumnsDataTypes(rows);
+    expect(guessedTypes.phone).toBe('string');
+  });
 });

--- a/src/fetchSheet/cleanRows/columnsDataTypes.ts
+++ b/src/fetchSheet/cleanRows/columnsDataTypes.ts
@@ -7,7 +7,7 @@ const checkType = (val: any): string => {
   // try to determine type based on the cell value
   if (!val || val === '') return 'null';
   // sheets apparently leaves commas in some numbers depending on formatting
-  if (val.replace(/-?[,\.\d]/g, '').length === 0 && val !== '') return 'number';
+  if (val.replace(/^-|[,\.\d]/g, '').length === 0 && val !== '') return 'number';
   if (val === 'TRUE' || val === 'FALSE') return 'boolean';
   return 'string';
 };


### PR DESCRIPTION
Phone numbers often have infix dash signs to denote area code, number and extension. This change ensures such values don't a) convert to 'number' and b) then fail parsing (thus become NaN).

Closes #36 